### PR TITLE
ログインフォーム作成

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -38,7 +38,9 @@
     ]
   },
   "devDependencies": {
+    "@reduxjs/toolkit": "^1.7.1",
     "axios": "^0.24.0",
+    "react-redux": "^7.2.6",
     "react-router-dom": "^6.2.1"
   }
 }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -12,22 +12,29 @@ import SignIn from "./components/account/SignIn";
 import SignOut from "./components/account/SignOut";
 import Show from "./components/account/Show";
 import Delete from "./components/account/Delete";
+import Account from "./components/account/Account";
+import { Provider } from 'react-redux'
+import store from './store'
+
 
 axios.defaults.withCredentials = true;
 function App() {
   const rootElement = document.getElementById("root");
   render (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<HelloReact />} />
-        <Route path="count-up-down" element={<CountUpDown />} />
-        <Route path="sign-up" element={<SignUp />} />
-        <Route path="sign-in" element={<SignIn />} />
-        <Route path="sign-out" element={<SignOut />} />
-        <Route path="show/:id" element={<Show />} />
-        <Route path="delete/:id" element={<Delete />} />
-      </Routes>
-    </BrowserRouter>,
+    <Provider store={store}>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<HelloReact />} />
+          <Route path="count-up-down" element={<CountUpDown />} />
+          <Route path="sign-up" element={<SignUp />} />
+          <Route path="sign-in" element={<SignIn />} />
+          <Route path="sign-out" element={<SignOut />} />
+          <Route path="show/:id" element={<Show />} />
+          <Route path="delete/:id" element={<Delete />} />
+          <Route path="account" element={<Account />} />
+        </Routes>
+      </BrowserRouter>
+    </Provider>,
   rootElement
   ); {
     return(

--- a/client/src/components/account/Account.jsx
+++ b/client/src/components/account/Account.jsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from 'react';
+import Navigation from "../../components/Navigation";
+import { useSelector, useDispatch } from 'react-redux'
+import { getUsers } from './UserSlice';
+import { getLoginUser } from './LoginUserSlice';
+import axios from 'axios';
+import { Navigate, Link } from 'react-router-dom';
+
+
+
+const Account = (props) => {
+    const count = useSelector((state) => state.counter.value);
+    const { users } = useSelector((state) => state.users);
+    const { login_user } = useSelector((state) => state.login_user);
+    const [check, setCheck] = useState()
+
+    const dispatch = useDispatch(); //sliceを叩くAPIの様なもの
+    const id = props.id;            //signinのIDを取得
+    console.log(props);
+
+    console.log(id);
+    console.log(login_user);
+    localStorage.setItem('id', id);
+    console.log(localStorage);
+    console.log(localStorage.getItem('id'));
+
+
+    useEffect(() => {               //以前state使ってlogin.userの値をリアルに変更できたが、今回出来ないような...それに伴って値は最後入手してレンダリングしてくれない様な感じ無理矢理レンダリングするもしくはstateするか
+        dispatch(getLoginUser(localStorage.getItem('id')))
+        // dispatch(getUsers());
+        axios.get("http://localhost:3001/api/v1/accounts/"+localStorage.getItem('id'))//無駄なAPIを叩いて力技どうしてもsliceの値をstateに保持する方法がわからず。返り値とかあるんですかね？
+        
+        .then(res => {
+            setCheck(res.data)
+        })
+    
+    }, []);
+
+    if(localStorage.getItem('id') === 'undefined'){
+        return <Navigate to={'/'} />
+    }
+
+    return(
+        <div>
+            <Navigation />
+            <main style={{ padding: "1rem 0" }}>
+                <h2>HelloReact</h2>
+                <span>{count}</span>
+                <h2>User</h2>
+      {users && users.map((user, index) => <div key={index}>{user.name}</div>)}
+                <h2>LoginUser</h2>
+                <div>
+                    {check ? (
+                        <div>
+                    id:{login_user.data.data.id}<br></br>
+                    first_name:{login_user.data.data.attributes.first_name}<br></br>
+                    last_name:{login_user.data.data.attributes.last_name}<br></br>
+                    email:{login_user.data.data.attributes.email}<br></br>
+                    phone:{login_user.data.data.attributes.phone}
+                        </div>
+                    ) : (
+                        <>nothing</>
+                    ) }
+                </div>
+            </main>
+        </div>
+    );
+}
+export default Account;

--- a/client/src/components/account/LoginUserSlice.js
+++ b/client/src/components/account/LoginUserSlice.js
@@ -1,0 +1,26 @@
+import { createSlice } from '@reduxjs/toolkit';
+import axios from 'axios';
+
+const loginUserSlice = createSlice({
+    name: 'login_user',
+    initialState: {
+      login_user: [],
+    },
+    reducers: {
+      setUser: (state, action) => {
+        state.login_user = action.payload;
+      },
+    },
+  });
+  
+  export const getLoginUser = (id) => {
+    return async (dispatch) => {
+      const res = await axios.get("http://localhost:3001/api/v1/accounts/"+id);
+      console.log(res.data.data);
+      dispatch(setUser(res));
+    };
+  };
+  
+  export const { setUser } = loginUserSlice.actions;
+  
+  export default loginUserSlice.reducer;

--- a/client/src/components/account/SignIn.jsx
+++ b/client/src/components/account/SignIn.jsx
@@ -3,12 +3,25 @@ import Navigation from "../../components/Navigation";
 // import { useForm } from "react-hook-form";
 import axios from 'axios';
 import { Navigate, Link } from 'react-router-dom'
+// import { useSelector, useDispatch } from 'react-redux'
+// import { decrement, increment } from './Slice'
+import Account from "../../components/account/Account";
+import { useSelector, useDispatch } from 'react-redux'
+
+
 
 export default function SignIn() {
     const [email, setEmail] = useState('')
 	const [password, setPassword] = useState('')
     const loginUrl = 'http://localhost:3001/api/v1/auth/sign_in'
 	const [redirect, setRedirect] = useState(false)
+	// const count = useSelector((state) => state.counter.value)
+	// const dispatch = useDispatch()
+	//2-6 idをaccountに渡してpropsで受け取るその値をsliceに渡すslice内でapi(get)叩くその値を持ってくる！！
+	const [id, setId] = useState()
+	const dispatch = useDispatch(); //sliceを叩くAPIの様なもの
+
+
 
     const submit = async (e) => {
 		// formのデフォルトの挙動をキャンセル
@@ -24,11 +37,21 @@ export default function SignIn() {
 			// API側ではCookieにTokenを保存している
 		// }, {withCredentials: true})
         })
-        .then(res => {
-            console.log(res.data.data.email);
-            localStorage.setItem('email', res.data.data.email);
-            console.log(localStorage.getItem('email'));
-        })
+		.then(res => {
+		console.log(res.data.data.id);
+		setId(res.data.data.id);
+		// dispatch(getLoginUser(localStorage.getItem('id')))
+
+		// dispatch(increment(res))//dispatchでsliceに渡せている様な？初期値に渡さないとリロードで消えるオブジェクトでSliceにどうか渡したい受け取り方の問題か
+        })                      //恐らくslice内でstateの要領で変更させる。いやdispatch関数？を使用してslice内の関数を呼び出す
+
+
+		//2-5localStorageで実装
+        // .then(res => {
+        //     console.log(res.data.data.email);
+        //     localStorage.setItem('email', res.data.data.email);
+        //     console.log(localStorage.getItem('email'));
+        // })
 
 		// リダイレクトフラグをTrue
 		setRedirect(true)
@@ -41,12 +64,18 @@ export default function SignIn() {
         // const login_token = Math.random().toString(36);
         // document.cookie = "login_token=" + login_token;
         // console.log(document.cookie);
-        // Homeへリダイレクトする
-        return <Navigate to={'/'} />
+        // リダイレクトする
+
+		//ページ遷移する且つ値が渡せない そもそもの根底が間違ってる気がしてきた
+		//どこからでもstoreにアクセスして値を保持してもらえるということはここでid渡してstoreでAPIを叩いて値を保持することが出来ないとリロードしたら消えてしまう気がしてきた
+        return <Account id={id}/>
+		// return <Navigate to={"/account"} id={id} />
     }
 
     return(
         <div>
+		    <Navigation />
+
             <form onSubmit={submit}>
 				<h1 className="h3 mb-3 fw-normal">Please sign in</h1>
  

--- a/client/src/components/account/SignOut.jsx
+++ b/client/src/components/account/SignOut.jsx
@@ -4,9 +4,10 @@ import { Link } from "react-router-dom";
 
 export default function SignOut() {
     // document.cookie = "login_token=; max-age=0";
-    localStorage.removeItem("email");
+    // localStorage.removeItem("email");
     return(
         <div>
+            <Navigation />
             <main style={{ padding: "1rem 0" }}>
                 <h2>LogOutしました</h2>
                 <Link to="/sign-in">SignIn</Link>

--- a/client/src/components/account/SignUp.jsx
+++ b/client/src/components/account/SignUp.jsx
@@ -194,6 +194,7 @@ export default function SignUp() {
 
     return (
         <div>
+            <Navigation />
             <main style={{ padding: "1rem 0" }}>
                 <h2>SignUp</h2>
             </main>

--- a/client/src/components/account/Slice.js
+++ b/client/src/components/account/Slice.js
@@ -1,0 +1,27 @@
+import { createSlice } from '@reduxjs/toolkit'
+import { SignIn } from "../../components/account/SignIn";
+
+
+export const counterSlice = createSlice({
+  name: 'counter',
+  initialState: {
+    value: 0
+  },
+  reducers: {
+    increment: (state) => {
+      // Redux Toolkit allows us to write "mutating" logic in reducers. It
+      // doesn't actually mutate the state because it uses the Immer library,
+      // which detects changes to a "draft state" and produces a brand new
+      // immutable state based off those changes
+      state.value += 1
+    },
+    incrementByAmount: (state, action) => {
+      state.value += action.payload
+    },
+  },
+})
+
+// Action creators are generated for each case reducer function
+export const { increment, decrement, incrementByAmount } = counterSlice.actions
+
+export default counterSlice.reducer

--- a/client/src/components/account/UserSlice.js
+++ b/client/src/components/account/UserSlice.js
@@ -1,0 +1,26 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const usersSlice = createSlice({
+    name: 'users',
+    initialState: {
+      users: [],
+    },
+    reducers: {
+      setUsers: (state, action) => {
+        state.users = action.payload;
+      },
+    },
+  });
+  
+  export const getUsers = () => {
+    return async (dispatch) => {
+      const res = await fetch('https://jsonplaceholder.typicode.com/users');
+      const data = await res.json();
+      console.log(data);
+      dispatch(setUsers(data));
+    };
+  };
+  
+  export const { setUsers } = usersSlice.actions;
+  
+  export default usersSlice.reducer;

--- a/client/src/store.js
+++ b/client/src/store.js
@@ -1,0 +1,14 @@
+import { configureStore } from '@reduxjs/toolkit'
+import counterReducer from './components/account/Slice'
+import UserReducer from './components/account/UserSlice'
+import loginUserReducer from './components/account/LoginUserSlice'
+
+
+
+export default configureStore({
+  reducer: {
+    counter: counterReducer,
+    users: UserReducer,
+    login_user: loginUserReducer
+  }
+})

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1015,7 +1015,7 @@
     core-js-pure "^3.20.2"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.16.7"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz"
   integrity sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==
@@ -1314,6 +1314,16 @@
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
     source-map "^0.7.3"
+
+"@reduxjs/toolkit@^1.7.1":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.7.1.tgz#994962aeb7df3c77be343dd2ad1aa48221dbaa0c"
+  integrity sha512-wXwXYjBVz/ItxB7SMzEAMmEE/FBiY1ze18N+VVVX7NtVbRUrdOGKhpQMHivIJfkbJvSdLUU923a/yAagJQzY0Q==
+  dependencies:
+    immer "^9.0.7"
+    redux "^4.1.2"
+    redux-thunk "^2.4.1"
+    reselect "^4.1.5"
 
 "@rollup/plugin-babel@^5.2.0":
   version "5.3.0"
@@ -1663,7 +1673,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/hoist-non-react-statics@^3.0.1":
+"@types/hoist-non-react-statics@^3.0.1", "@types/hoist-non-react-statics@^3.3.0":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
   integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
@@ -1759,6 +1769,16 @@
   version "1.2.4"
   resolved "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
+
+"@types/react-redux@^7.1.20":
+  version "7.1.22"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.22.tgz#0eab76a37ef477cc4b53665aeaf29cb60631b72a"
+  integrity sha512-GxIA1kM7ClU73I6wg9IRTVwSO9GS+SAKZKe0Enj+82HMU6aoESFU2HNAdNi3+J53IaOHPiUfT3kSG4L828joDQ==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.0"
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+    redux "^4.0.0"
 
 "@types/react@*":
   version "17.0.38"
@@ -4426,7 +4446,7 @@ history@^5.2.0:
   dependencies:
     "@babel/runtime" "^7.7.6"
 
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -6974,10 +6994,22 @@ react-is@^16.13.1, react-is@^16.7.0:
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-is@^17.0.1:
+react-is@^17.0.1, react-is@^17.0.2:
   version "17.0.2"
   resolved "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
+react-redux@^7.2.6:
+  version "7.2.6"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.6.tgz#49633a24fe552b5f9caf58feb8a138936ddfe9aa"
+  integrity sha512-10RPdsz0UUrRL1NZE0ejTkucnclYSgXp5q+tB5SWx2qeG2ZJQJyymgAhwKy73yiL/13btfB6fPr+rgbMAaZIAQ==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    "@types/react-redux" "^7.1.20"
+    hoist-non-react-statics "^3.3.2"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^17.0.2"
 
 react-refresh@^0.11.0:
   version "0.11.0"
@@ -7106,6 +7138,18 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+redux-thunk@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.4.1.tgz#0dd8042cf47868f4b29699941de03c9301a75714"
+  integrity sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==
+
+redux@^4.0.0, redux@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.1.2.tgz#140f35426d99bb4729af760afcf79eaaac407104"
+  integrity sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+
 regenerate-unicode-properties@^9.0.0:
   version "9.0.0"
   resolved "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-9.0.0.tgz"
@@ -7202,6 +7246,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
+reselect@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.5.tgz#852c361247198da6756d07d9296c2b51eddb79f6"
+  integrity sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## 課題
- ログインフォーム作成

## 実装内容
- redux toolkitを使用してログイン情報を表示(slice,store使用)

## スクリーンショット
- ログイン後画面(account.jsx)
<img width="1432" alt="スクリーンショット 2022-02-02 18 16 08" src="https://user-images.githubusercontent.com/59953143/152125765-b57d8b57-c9d2-4d8c-988e-ab0dbceb4343.png">

## 特に見て欲しい確認観点
- 現状SignIn.jsxでpostした返り値をAccount.jsxに渡しております。
- Account.jsxでdispatchにidを渡しLoginUserSlice内でidを元にgetAPIを叩いております。

### 問題点
-  URLがAccountで無くsigninのままでの遷移となりリロードするとSigIn.jsxの画面になってしまう。
Navigateを使うがその場合idが渡せない。

- useEffectを使用する際Account.jsxの55行目で使用しているdataが無いとエラー表示
以前はstateのみの使用でlength < 0の条件分岐で対処したが、今回useSelectorを使用しているので
stateとの組み合わせが上手くいかず。無理矢理idでAPIを叩いて返り値で判断しております。

## その他,質問
- Navigateを使用しid等の渡す方法はございますでしょうか？
- useSelectorとuseStateの併用方法をご教授頂きたいです。
- 現状の実装 SignIn.jsx(id渡す)→Account.jsx(id渡す)→LoginUser.js(idでAPI叩く、返り値(user情報))→Account.jsxで実装出来そうでしょうか？

### 長々と見辛いかもしれませんが一度ご確認の程よろしくお願いいたします！
